### PR TITLE
Add NoDigZombies modlet to halve zombie hearing range

### DIFF
--- a/Mods/NoDigZombies/Config/entityclasses.xml
+++ b/Mods/NoDigZombies/Config/entityclasses.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configs>
+    <set xpath="/entity_classes/entity_class[contains(@name, 'zombie')]/property[@name='HearingRange']/@value"
+         value="string(number(@value) div 2)" />
+</configs>

--- a/Mods/NoDigZombies/ModInfo.xml
+++ b/Mods/NoDigZombies/ModInfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+    <ModInfo>
+        <Name value="NoDigZombies" />
+        <Description value="Reduce zombie hearing range underground." />
+        <Author value="ChatGPT" />
+        <Version value="1.0" />
+        <GameVersion value="2.3" />
+    </ModInfo>
+</xml>


### PR DESCRIPTION
## Summary
- add the NoDigZombies modlet structure targeting 7 Days to Die v2.3
- configure entityclasses.xml patch to halve the HearingRange of every zombie entity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17f04f8888322be4894a9347154d2