### PR TITLE
Add visibility overlay HUD and diagnostics

### DIFF
--- a/src/ZombiesDeOP/Harmony/EnemyDetectionPatch.cs
+++ b/src/ZombiesDeOP/Harmony/EnemyDetectionPatch.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using UnityEngine;
+using ZombiesDeOP.Systems;
+using ZombiesDeOP.Utilities;
+
+namespace ZombiesDeOP.Harmony
+{
+    [HarmonyPatch(typeof(EntityEnemy))]
+    [HarmonyPatch("Update")]
+    public static class EnemyDetectionPatch
+    {
+        private const float DetectionDistance = 10f;
+
+        private static void Postfix(EntityEnemy __instance)
+        {
+            if (__instance == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var overlay = VisibilityOverlaySystem.OverlayComponent;
+                if (overlay == null)
+                {
+                    return;
+                }
+
+                var world = GameManager.Instance?.World;
+                if (world == null)
+                {
+                    return;
+                }
+
+                var localPlayer = world.GetPrimaryPlayer() as EntityPlayerLocal;
+                if (localPlayer == null)
+                {
+                    return;
+                }
+
+                bool isCrouching = ResolveCrouchState(localPlayer);
+                float distanceToPlayer = __instance.GetDistance(localPlayer);
+                bool isTargetingPlayer = __instance.GetAttackTarget() == localPlayer;
+
+                ModLogger.Debug($"👁️ [ZombiesDeOP] Detección -> Enemigo: {__instance.EntityName}, Agachado: {isCrouching}, Distancia: {distanceToPlayer:F2}, Target: {isTargetingPlayer}");
+
+                if (isTargetingPlayer)
+                {
+                    overlay.SetState("seen");
+                    ModLogger.Log("👁️ [ZombiesDeOP] Estado detectado: SEEN");
+                    return;
+                }
+
+                if (isCrouching && distanceToPlayer <= DetectionDistance)
+                {
+                    overlay.SetState("hidden");
+                    ModLogger.Log("👁️ [ZombiesDeOP] Estado detectado: HIDDEN");
+                }
+                else if (distanceToPlayer > DetectionDistance)
+                {
+                    overlay.SetState("none");
+                    ModLogger.Debug("👁️ [ZombiesDeOP] Estado detectado: NONE (fuera de rango)");
+                }
+                else
+                {
+                    overlay.SetState("none");
+                    ModLogger.Debug("👁️ [ZombiesDeOP] Estado detectado: NONE (sin condiciones)");
+                }
+            }
+            catch (Exception e)
+            {
+                ModLogger.Error($"❌ [ZombiesDeOP] Error en EnemyDetectionPatch: {e}");
+            }
+        }
+
+        private static bool ResolveCrouchState(EntityPlayerLocal player)
+        {
+            if (player == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                var type = player.GetType();
+                var property = AccessTools.Property(type, "IsCrouching") ?? AccessTools.Property(type, "Crouching");
+                if (property != null)
+                {
+                    if (property.GetValue(player) is bool propertyValue)
+                    {
+                        return propertyValue;
+                    }
+                }
+
+                var field = AccessTools.Field(type, "isCrouching") ?? AccessTools.Field(type, "Crouching");
+                if (field != null && field.GetValue(player) is bool fieldValue)
+                {
+                    return fieldValue;
+                }
+            }
+            catch (TargetInvocationException e)
+            {
+                ModLogger.Debug($"👁️ [ZombiesDeOP] Error evaluando crouch (invocación): {e.InnerException ?? e}");
+            }
+            catch (Exception e)
+            {
+                ModLogger.Debug($"👁️ [ZombiesDeOP] Error evaluando crouch: {e}");
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/ZombiesDeOP/Systems/UIOverlayComponent.cs
+++ b/src/ZombiesDeOP/Systems/UIOverlayComponent.cs
@@ -1,0 +1,178 @@
+using System;
+using System.IO;
+using UnityEngine;
+using ZombiesDeOP.Utilities;
+
+namespace ZombiesDeOP.Systems
+{
+    public class UIOverlayComponent : MonoBehaviour
+    {
+        private Texture2D hiddenTexture;
+        private Texture2D seenTexture;
+        private Texture2D currentTexture;
+        private string currentState = "none";
+        private bool isVisible;
+
+        private const string HiddenImageName = "hidden.png";
+        private const string SeenImageName = "seen.png";
+
+        private void Awake()
+        {
+            ModLogger.Log("🧩 [ZombiesDeOP] UIOverlayComponent adjunto");
+        }
+
+        private void Start()
+        {
+            ModLogger.Log("🧩 [ZombiesDeOP] Inicializando UIOverlayComponent");
+            LoadTextures();
+            HideTexture();
+        }
+
+        private void LoadTextures()
+        {
+            hiddenTexture = LoadTexture(HiddenImageName);
+            seenTexture = LoadTexture(SeenImageName);
+
+            bool hiddenLoaded = hiddenTexture != null;
+            bool seenLoaded = seenTexture != null;
+            ModLogger.Log($"🧩 [ZombiesDeOP] Texturas cargadas -> Hidden: {hiddenLoaded}, Seen: {seenLoaded}");
+        }
+
+        private Texture2D LoadTexture(string imageName)
+        {
+            try
+            {
+                string[] candidates =
+                {
+                    Path.Combine("Resources", imageName),
+                    Path.Combine("imgs", imageName),
+                    imageName
+                };
+
+                string texturePath = string.Empty;
+                foreach (string candidate in candidates)
+                {
+                    string resolved = ModContext.ResolveConfigPath(candidate);
+                    if (File.Exists(resolved))
+                    {
+                        texturePath = resolved;
+                        break;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(texturePath))
+                {
+                    ModLogger.Warning($"⚠️ [ZombiesDeOP] Textura no encontrada para {imageName}");
+                    return null;
+                }
+
+                byte[] data = File.ReadAllBytes(texturePath);
+                var texture = new Texture2D(2, 2, TextureFormat.RGBA32, false)
+                {
+                    filterMode = FilterMode.Bilinear,
+                    wrapMode = TextureWrapMode.Clamp
+                };
+
+                if (!ImageConversion.LoadImage(texture, data))
+                {
+                    ModLogger.Error($"❌ [ZombiesDeOP] Falló la carga de imagen: {texturePath}");
+                    Destroy(texture);
+                    return null;
+                }
+
+                ModLogger.Debug($"🧩 [ZombiesDeOP] Textura cargada: {texturePath}");
+                return texture;
+            }
+            catch (Exception e)
+            {
+                ModLogger.Error($"❌ [ZombiesDeOP] Excepción cargando textura {imageName}: {e}");
+                return null;
+            }
+        }
+
+        public void SetState(string state)
+        {
+            if (string.IsNullOrEmpty(state))
+            {
+                state = "none";
+            }
+
+            if (currentState == state)
+            {
+                return;
+            }
+
+            currentState = state;
+            ModLogger.Log($"🧩 [ZombiesDeOP] Cambiando estado de visibilidad a: {state}");
+
+            switch (state)
+            {
+                case "hidden":
+                    currentTexture = hiddenTexture;
+                    isVisible = hiddenTexture != null;
+                    if (!isVisible)
+                    {
+                        ModLogger.Warning("⚠️ [ZombiesDeOP] Textura HIDDEN no disponible");
+                    }
+                    else
+                    {
+                        ModLogger.Log("🧩 [ZombiesDeOP] Mostrando icono HIDDEN");
+                    }
+                    break;
+                case "seen":
+                    currentTexture = seenTexture;
+                    isVisible = seenTexture != null;
+                    if (!isVisible)
+                    {
+                        ModLogger.Warning("⚠️ [ZombiesDeOP] Textura SEEN no disponible");
+                    }
+                    else
+                    {
+                        ModLogger.Log("🧩 [ZombiesDeOP] Mostrando icono SEEN");
+                    }
+                    break;
+                default:
+                    HideTexture();
+                    break;
+            }
+        }
+
+        private void HideTexture()
+        {
+            isVisible = false;
+            currentTexture = null;
+            currentState = "none";
+            ModLogger.Log("🧩 [ZombiesDeOP] Ocultando icono de visibilidad");
+        }
+
+        private void OnGUI()
+        {
+            if (!isVisible || currentTexture == null)
+            {
+                return;
+            }
+
+            const int size = 64;
+            var rect = new Rect(50f, 50f, size, size);
+            GUI.DrawTexture(rect, currentTexture, ScaleMode.ScaleToFit, true);
+        }
+
+        private void OnDestroy()
+        {
+            if (hiddenTexture != null)
+            {
+                Destroy(hiddenTexture);
+                hiddenTexture = null;
+            }
+
+            if (seenTexture != null)
+            {
+                Destroy(seenTexture);
+                seenTexture = null;
+            }
+
+            currentTexture = null;
+            ModLogger.Debug("🧩 [ZombiesDeOP] UIOverlayComponent destruido");
+        }
+    }
+}

--- a/src/ZombiesDeOP/Systems/VisibilityOverlaySystem.cs
+++ b/src/ZombiesDeOP/Systems/VisibilityOverlaySystem.cs
@@ -1,0 +1,58 @@
+using System;
+using UnityEngine;
+using ZombiesDeOP.Utilities;
+
+namespace ZombiesDeOP.Systems
+{
+    public static class VisibilityOverlaySystem
+    {
+        private static GameObject overlayObject;
+        private static UIOverlayComponent overlayComponent;
+        private static bool initialized;
+
+        public static UIOverlayComponent OverlayComponent => overlayComponent;
+
+        public static void Initialize()
+        {
+            if (initialized)
+            {
+                return;
+            }
+
+            try
+            {
+                overlayObject = new GameObject("ZombiesDeOP_UI");
+                overlayObject.hideFlags = HideFlags.HideAndDontSave;
+                UnityEngine.Object.DontDestroyOnLoad(overlayObject);
+
+                overlayComponent = overlayObject.AddComponent<UIOverlayComponent>();
+
+                initialized = true;
+                ModLogger.Log("🖼️ [ZombiesDeOP] Overlay de visibilidad inicializado");
+            }
+            catch (Exception e)
+            {
+                ModLogger.Error($"❌ [ZombiesDeOP] Error al crear overlay de visibilidad: {e}");
+                Shutdown();
+            }
+        }
+
+        public static void Shutdown()
+        {
+            if (!initialized)
+            {
+                return;
+            }
+
+            if (overlayObject != null)
+            {
+                UnityEngine.Object.Destroy(overlayObject);
+                overlayObject = null;
+            }
+
+            overlayComponent = null;
+            initialized = false;
+            ModLogger.Log("🧹 [ZombiesDeOP] Overlay de visibilidad desmontado");
+        }
+    }
+}

--- a/src/ZombiesDeOP/ZombiesDeOPMain.cs
+++ b/src/ZombiesDeOP/ZombiesDeOPMain.cs
@@ -12,6 +12,7 @@ namespace ZombiesDeOP
     {
         private const string HARMONY_ID = "com.juanhernandez.zombiesdeop.a21";
         private Harmony harmony;
+        private static bool overlayInitialized;
 
         public void InitMod(Mod mod)
         {
@@ -29,6 +30,7 @@ namespace ZombiesDeOP
 
                 DetectionSystem.Initialize();
                 HUDManager.Initialize();
+                InitializeOverlay();
                 BehaviorManager.Initialize();
 
                 ModLogger.Log("✅ [ZombiesDeOP] Mod cargado exitosamente");
@@ -46,12 +48,52 @@ namespace ZombiesDeOP
                 harmony?.UnpatchAll(HARMONY_ID);
                 HUDManager.Shutdown();
                 DetectionSystem.Shutdown();
+                ShutdownOverlay();
                 BehaviorManager.Shutdown();
                 ModLogger.Log("✅ [ZombiesDeOP] Mod descargado correctamente");
             }
             catch (Exception e)
             {
                 ModLogger.Error($"❌ [ZombiesDeOP] Error en shutdown: {e}");
+            }
+        }
+
+        private static void InitializeOverlay()
+        {
+            if (overlayInitialized)
+            {
+                return;
+            }
+
+            try
+            {
+                VisibilityOverlaySystem.Initialize();
+                overlayInitialized = true;
+            }
+            catch (Exception e)
+            {
+                ModLogger.Error($"❌ [ZombiesDeOP] Error al inicializar overlay: {e}");
+            }
+        }
+
+        private static void ShutdownOverlay()
+        {
+            if (!overlayInitialized)
+            {
+                return;
+            }
+
+            try
+            {
+                VisibilityOverlaySystem.Shutdown();
+            }
+            catch (Exception e)
+            {
+                ModLogger.Error($"❌ [ZombiesDeOP] Error al detener overlay: {e}");
+            }
+            finally
+            {
+                overlayInitialized = false;
             }
         }
     }


### PR DESCRIPTION
## Summary
- initialize a persistent visibility overlay system when the mod loads and tear it down on shutdown
- implement a UIOverlayComponent that loads hidden/seen textures, renders the icon, and logs visibility state changes
- add a Harmony enemy update patch that drives the overlay based on targeting, crouching, and distance with detailed diagnostics

## Testing
- dotnet build src/ZombiesDeOP/ZombiesDeOP.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c75a0fdc8322b98eb391d136b3fa