### PR TITLE
Update ZombiesDeOP reference hint paths

### DIFF
--- a/src/ZombiesDeOP/ZombiesDeOP.csproj
+++ b/src/ZombiesDeOP/ZombiesDeOP.csproj
@@ -13,16 +13,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>$(7DTD_Managed)\0Harmony.dll</HintPath>
+      <HintPath>C:\Users\braia\AppData\Roaming\7DaysToDie\Mods\0_TFP_Harmony\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(7DTD_Managed)\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>$(7DTD_Managed)\UnityEngine.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(7DTD_Managed)\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- point project references at the correct 7 Days to Die managed assemblies using absolute hint paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2cd2ba3148322a5d7eae8751563d5