### PR TITLE
Configure ZombiesDeOP project for modern build targets

### DIFF
--- a/src/ZombiesDeOP/ZombiesDeOP.csproj
+++ b/src/ZombiesDeOP/ZombiesDeOP.csproj
@@ -5,6 +5,11 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Nullable>disable</Nullable>
+    <LangVersion>latestMajor</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <PlatformTarget>x64</PlatformTarget>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>ZombiesDeOP</AssemblyName>
@@ -12,6 +17,27 @@
     <Version>2.4.0</Version>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="mscorlib">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\mscorlib.dll</HintPath>
+    </Reference>
+    <Reference Include="System">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\System.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\System.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\System.Xml.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\System.Xml.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\System.Runtime.Serialization.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data">
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\System.Data.dll</HintPath>
+    </Reference>
     <Reference Include="0Harmony">
       <HintPath>C:\Users\braia\AppData\Roaming\7DaysToDie\Mods\0_TFP_Harmony\0Harmony.dll</HintPath>
     </Reference>


### PR DESCRIPTION
## Summary
- set the project to compile with the latest C# language version, allow unsafe code, enable optimizations, target x64, and disable implicit framework references
- add explicit references to the 7 Days to Die .NET framework assemblies to avoid duplicate local copies when building the mod

## Testing
- dotnet build *(fails in container: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cf99fcb883228a204c1987481aa8