### PR TITLE
Fix Harmony target resolution and HUD OnGUI usage

### DIFF
--- a/src/ZombiesDeOP/Systems/HUDManager.cs
+++ b/src/ZombiesDeOP/Systems/HUDManager.cs
@@ -9,7 +9,7 @@ namespace ZombiesDeOP.Systems
         private sealed class HudRuntime : MonoBehaviour
         {
             private void Update() => OnGameUpdate();
-            private void OnGUI() => OnGameGUI();
+            private void OnGUI() => HUDManager.OnGUI();
         }
 
         private static readonly Queue<string> Messages = new();
@@ -80,7 +80,7 @@ namespace ZombiesDeOP.Systems
             }
         }
 
-        private static void OnGameGUI()
+        public static void OnGUI()
         {
             if (!initialized) return;
             if (Messages.Count == 0) return;


### PR DESCRIPTION
## Summary
- broaden the Harmony enemy update hook discovery and add debug logging for runtime ticks
- confine HUD GUI rendering to the Unity OnGUI callback while keeping initialization logic clean
- make the detection runtime resolve World.GetEntitiesInBounds overloads with more flexible reflection handling

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e41fb7707483229c689c52cc917525