### PR TITLE
Make ZombiesDeOP project portable and legacy-friendly

### DIFF
--- a/src/ZombiesDeOP/Systems/DetectionSystem.cs
+++ b/src/ZombiesDeOP/Systems/DetectionSystem.cs
@@ -40,7 +40,7 @@ namespace ZombiesDeOP.Systems
             public bool IsValid => Enemy != null && Enemy.IsAlive();
         }
 
-        private static readonly Dictionary<int, EnemySnapshot> EnemyObservations = new();
+        private static readonly Dictionary<int, EnemySnapshot> EnemyObservations = new Dictionary<int, EnemySnapshot>();
         private const float HUD_COOLDOWN = 1.25f;
         private const float SNAPSHOT_TTL = 1.5f;
 
@@ -279,7 +279,7 @@ namespace ZombiesDeOP.Systems
 
         private static class DetectionHelpers
         {
-            private static readonly List<Func<EntityPlayerLocal, bool?>> CrouchResolvers = new();
+            private static readonly List<Func<EntityPlayerLocal, bool?>> CrouchResolvers = new List<Func<EntityPlayerLocal, bool?>>();
             private static readonly MethodInfo CanSeeMethod;
 
             static DetectionHelpers()

--- a/src/ZombiesDeOP/Systems/DetectionSystemRuntime.cs
+++ b/src/ZombiesDeOP/Systems/DetectionSystemRuntime.cs
@@ -29,8 +29,8 @@ namespace ZombiesDeOP.Systems
 
         private static readonly Type EntityFilterType = typeof(EntityAlive);
 
-        private readonly List<Entity> _entityBuffer = new();
-        private readonly List<EntityEnemy> _enemyBuffer = new();
+        private readonly List<Entity> _entityBuffer = new List<Entity>();
+        private readonly List<EntityEnemy> _enemyBuffer = new List<EntityEnemy>();
 
         private float _lastTickTime;
         private float _lastWorldWarning;

--- a/src/ZombiesDeOP/Systems/HUDManager.cs
+++ b/src/ZombiesDeOP/Systems/HUDManager.cs
@@ -12,7 +12,7 @@ namespace ZombiesDeOP.Systems
             private void OnGUI() => HUDManager.OnGUI();
         }
 
-        private static readonly Queue<string> Messages = new();
+        private static readonly Queue<string> Messages = new Queue<string>();
         private static bool initialized;
         private static float displayTimer;
         private static GameObject runtimeObject;

--- a/src/ZombiesDeOP/ZombiesDeOP.csproj
+++ b/src/ZombiesDeOP/ZombiesDeOP.csproj
@@ -17,40 +17,61 @@
     <Version>2.4.0</Version>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GameRoot Condition="'$(GameRoot)' == '' and '$(7DTD_DIR)' != ''">$(7DTD_DIR)</GameRoot>
+    <GameRoot Condition="'$(GameRoot)' == ''">C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die</GameRoot>
+    <ManagedDir>$(GameRoot)\7DaysToDie_Data\Managed</ManagedDir>
+    <HarmonyCandidate>$(APPDATA)\7DaysToDie\Mods\0_TFP_Harmony\0Harmony.dll</HarmonyCandidate>
+    <HarmonyPath Condition="'$(HarmonyPath)' == '' and Exists('$(HarmonyCandidate)')">$(HarmonyCandidate)</HarmonyPath>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>C:\Users\braia\AppData\Roaming\7DaysToDie\Mods\0_TFP_Harmony\0Harmony.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-
     <Reference Include="Assembly-CSharp">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(ManagedDir)\Assembly-CSharp.dll</HintPath>
       <Private>false</Private>
     </Reference>
-
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.dll</HintPath>
       <Private>false</Private>
     </Reference>
-
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.CoreModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
-
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
-
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
-
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\7 Days To Die\7DaysToDie_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(ManagedDir)\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(HarmonyPath)' != ''">
+    <Reference Include="0Harmony">
+      <HintPath>$(HarmonyPath)</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(HarmonyPath)' == ''">
+    <PackageReference Include="Lib.Harmony" Version="2.2.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <Target Name="CopyToMods" AfterTargets="Build" Condition="'$(MODS_DIR)' != ''">
+    <PropertyGroup>
+      <ModDeployDir>$(MODS_DIR)\ZombiesDeOP</ModDeployDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(ModDeployDir)" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModDeployDir)" SkipUnchangedFiles="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- add environment-based game path detection to ZombiesDeOP.csproj with conditional Harmony resolution and binding redirect settings
- point Unity/Assembly-CSharp references at the managed folder via properties and add an optional CopyToMods deployment target
- replace target-typed `new()` expressions with explicit constructors to keep the code compatible with C# 7.3 compilers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e49214e6008322b19dae6241ed187b