### PR TITLE
Expand hostile detection to EntityAlive hierarchy

### DIFF
--- a/src/ZombiesDeOP/Harmony/EnemyDetectionPatch.cs
+++ b/src/ZombiesDeOP/Harmony/EnemyDetectionPatch.cs
@@ -59,7 +59,12 @@ namespace ZombiesDeOP.Harmony
 
         public static void Postfix(object __instance)
         {
-            if (__instance is not EntityEnemy enemy)
+            if (__instance is not EntityAlive entity)
+            {
+                return;
+            }
+
+            if (!BehaviorManager.IsHostileEntity(entity))
             {
                 return;
             }
@@ -68,7 +73,7 @@ namespace ZombiesDeOP.Harmony
             {
                 try
                 {
-                    ModLogger.LogDebug($"EnemyDetectionPatch.Postfix -> {enemy.EntityName} ({enemy.entityId})");
+                    ModLogger.LogDebug($"EnemyDetectionPatch.Postfix -> {entity.EntityName} ({entity.entityId})");
                 }
                 catch
                 {
@@ -76,7 +81,7 @@ namespace ZombiesDeOP.Harmony
                 }
             }
 
-            DetectionSystemRuntime.NotifyHarmonyTick(enemy);
+            DetectionSystemRuntime.NotifyHarmonyTick(entity);
         }
 
         private static IEnumerable<MethodInfo> GetCandidateMethods(Type type)

--- a/src/ZombiesDeOP/Systems/BehaviorManager.cs
+++ b/src/ZombiesDeOP/Systems/BehaviorManager.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reflection;
 using HarmonyLib;
 using ZombiesDeOP.Utilities;
 
@@ -23,30 +25,82 @@ namespace ZombiesDeOP.Systems
             initialized = false;
         }
 
-        private static void ApplyBehaviorInsights(EntityEnemy enemy)
+        private static void ApplyBehaviorInsights(EntityAlive entity)
         {
-            if (!initialized || enemy == null)
+            if (!initialized || entity == null)
             {
                 return;
             }
 
-            if (!enemy.IsAlive())
+            if (!entity.IsAlive())
             {
                 return;
             }
 
             if (ModSettings.DebugMode)
             {
-                ModLogger.LogDebug($"Refrescando IA para {enemy.EntityName} ({enemy.entityId})");
+                ModLogger.LogDebug($"Refrescando IA para {entity.EntityName} ({entity.entityId})");
             }
         }
 
-        [HarmonyPatch(typeof(EntityEnemy))]
-        [HarmonyPatch("OnAddedToWorld")]
-        private static class EntityEnemySpawnPatch
+        internal static bool IsHostileEntity(EntityAlive entity)
         {
-            private static void Postfix(EntityEnemy __instance)
+            if (entity == null)
             {
+                return false;
+            }
+
+            if (entity is EntityZombie || entity is EntityEnemyAnimal || entity is EntityBandit)
+            {
+                return true;
+            }
+
+            var name = entity.GetType().Name;
+            if (name.Contains("Enemy", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("Zombie", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("Bandit", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("Spider", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("Demon", StringComparison.OrdinalIgnoreCase) ||
+                name.Contains("Mutant", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            try
+            {
+                var aiField = entity.GetType().GetField("aiTasks", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (aiField != null)
+                {
+                    var value = aiField.GetValue(entity)?.ToString();
+                    if (!string.IsNullOrEmpty(value) && value.Contains("Attack", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                // Ignorar cualquier error de reflexión: fallback seguro
+            }
+
+            return false;
+        }
+
+        [HarmonyPatch(typeof(EntityAlive), nameof(EntityAlive.OnAddedToWorld))]
+        private static class EntitySpawnPatch
+        {
+            static EntitySpawnPatch()
+            {
+                ModLogger.Info("[ZombiesDeOP] Harmony patch target: EntityAlive.OnAddedToWorld (OK)");
+            }
+
+            private static void Postfix(EntityAlive __instance)
+            {
+                if (!IsHostileEntity(__instance))
+                {
+                    return;
+                }
+
                 ApplyBehaviorInsights(__instance);
             }
         }

--- a/src/ZombiesDeOP/Systems/DetectionSystem.cs
+++ b/src/ZombiesDeOP/Systems/DetectionSystem.cs
@@ -19,7 +19,7 @@ namespace ZombiesDeOP.Systems
     {
         private sealed class EnemySnapshot
         {
-            public EnemySnapshot(EntityEnemy enemy, EntityPlayerLocal player, float radius)
+            public EnemySnapshot(EntityAlive enemy, EntityPlayerLocal player, float radius)
             {
                 Enemy = enemy;
                 EntityId = enemy?.entityId ?? -1;
@@ -31,7 +31,7 @@ namespace ZombiesDeOP.Systems
                 HiddenCandidate = !Seen && Distance <= radius;
             }
 
-            public EntityEnemy Enemy { get; }
+            public EntityAlive Enemy { get; }
             public int EntityId { get; }
             public float Timestamp { get; }
             public float Distance { get; }
@@ -75,7 +75,7 @@ namespace ZombiesDeOP.Systems
             lastStateChangeTime = 0f;
         }
 
-        internal static void ProcessRuntimeTick(EntityPlayerLocal player, IList<EntityEnemy> enemies, float radius, UIOverlayComponent overlay)
+        internal static void ProcessRuntimeTick(EntityPlayerLocal player, IList<EntityAlive> enemies, float radius, UIOverlayComponent overlay)
         {
             if (!initialized || player == null)
             {
@@ -85,8 +85,8 @@ namespace ZombiesDeOP.Systems
             bool crouching = DetectionHelpers.ResolveCrouchState(player);
             bool seen = false;
             bool hiddenCandidate = false;
-            EntityEnemy seenEnemy = null;
-            EntityEnemy hiddenEnemy = null;
+            EntityAlive seenEnemy = null;
+            EntityAlive hiddenEnemy = null;
             float seenDistance = float.MaxValue;
             float hiddenDistance = float.MaxValue;
             int evaluated = 0;
@@ -135,7 +135,7 @@ namespace ZombiesDeOP.Systems
             ApplyState(state, referenceEnemy, referenceDistance, evaluated, overlay);
         }
 
-        internal static void ProcessHarmonyObservation(EntityPlayerLocal player, EntityEnemy enemy, float radius, UIOverlayComponent overlay)
+        internal static void ProcessHarmonyObservation(EntityPlayerLocal player, EntityAlive enemy, float radius, UIOverlayComponent overlay)
         {
             if (!initialized || player == null || enemy == null)
             {
@@ -148,8 +148,8 @@ namespace ZombiesDeOP.Systems
             bool crouching = DetectionHelpers.ResolveCrouchState(player);
             bool anySeen = false;
             bool hiddenCandidate = false;
-            EntityEnemy seenEnemy = null;
-            EntityEnemy hiddenEnemy = null;
+            EntityAlive seenEnemy = null;
+            EntityAlive hiddenEnemy = null;
             float seenDistance = float.MaxValue;
             float hiddenDistance = float.MaxValue;
             int evaluated = 0;
@@ -203,7 +203,7 @@ namespace ZombiesDeOP.Systems
             ModLogger.Info("👁️ [ZombiesDeOP] Estado de detección -> NONE (reinicio por falta de datos)");
         }
 
-        private static void ApplyState(DetectionState state, EntityEnemy enemy, float distance, int evaluated, UIOverlayComponent overlay)
+        private static void ApplyState(DetectionState state, EntityAlive enemy, float distance, int evaluated, UIOverlayComponent overlay)
         {
             if (!initialized)
             {
@@ -240,7 +240,7 @@ namespace ZombiesDeOP.Systems
             TryReportHud(state, enemy, distance);
         }
 
-        private static void TryReportHud(DetectionState state, EntityEnemy enemy, float distance)
+        private static void TryReportHud(DetectionState state, EntityAlive enemy, float distance)
         {
             if (enemy == null)
             {
@@ -289,7 +289,7 @@ namespace ZombiesDeOP.Systems
                 RegisterFieldGetter("isCrouching");
                 RegisterFieldGetter("crouching");
 
-                var enemyType = typeof(EntityEnemy);
+                var enemyType = typeof(EntityAlive);
                 var candidateParams = new[] { typeof(EntityAlive) };
                 CanSeeMethod = AccessTools.Method(enemyType, "CanSee", candidateParams);
                 if (CanSeeMethod == null)
@@ -324,7 +324,7 @@ namespace ZombiesDeOP.Systems
                 return false;
             }
 
-            public static bool TryCanSee(EntityEnemy enemy, EntityPlayerLocal player)
+            public static bool TryCanSee(EntityAlive enemy, EntityPlayerLocal player)
             {
                 if (enemy == null || player == null)
                 {
@@ -350,7 +350,7 @@ namespace ZombiesDeOP.Systems
                 return EstimateLineOfSight(enemy, player);
             }
 
-            private static bool EstimateLineOfSight(EntityEnemy enemy, EntityPlayerLocal player)
+            private static bool EstimateLineOfSight(EntityAlive enemy, EntityPlayerLocal player)
             {
                 Vector3 enemyEye = GetEyePosition(enemy);
                 Vector3 playerEye = GetEyePosition(player);

--- a/src/ZombiesDeOP/Systems/HUDManager.cs
+++ b/src/ZombiesDeOP/Systems/HUDManager.cs
@@ -57,7 +57,7 @@ namespace ZombiesDeOP.Systems
             initialized = false;
         }
 
-        public static void ReportDetection(EntityEnemy enemy, bool detected, float distance)
+        public static void ReportDetection(EntityAlive enemy, bool detected, float distance)
         {
             if (!initialized || enemy == null) return;
 


### PR DESCRIPTION
## Summary
- update BehaviorManager to hook EntityAlive.OnAddedToWorld, log the Harmony target, and share a generic hostility detector for vanilla and modded enemies
- refactor the detection runtime, core system, and HUD integration to operate on EntityAlive hostiles discovered via the shared helper and modern World.GetEntitiesInBounds signature
- ensure the Harmony enemy detection patch only forwards hostile EntityAlive instances to the runtime for consistent insights

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4a8313ffc8322ba8d9d6e8ad136c7